### PR TITLE
apply crop and flip transformations to bboxes and labels 

### DIFF
--- a/hackathon/augmentations.py
+++ b/hackathon/augmentations.py
@@ -11,7 +11,7 @@ def to_4d(image: tf.Tensor) -> tf.Tensor:
     2D image => [1, H, W, 1]
 
     Args:
-      image: The 2/3/4D input tensor.
+      image: The 2/3/4D input tensor.update-global-crops-bboxes
 
     Returns:
       A 4D image tensor.
@@ -467,14 +467,22 @@ def create_global_crops(
         seeds = tf.random.split(seed_crops[i], 5)
 
         if bboxes is not None:
-            # Example:
-            # crop, crop_bboxes, crop_validbboxes = random_resized_crop(
-            #     image, size=size, scale=scale, bboxes=bboxes, seed=seeds[0]
-            # )
-            # crop, crop_bboxes = random_horizontal_flip(
-            #     crop, bboxes=crop_bboxes, seed=seeds[1]
-            # )
-            raise NotImplementedError
+            crop, crop_bboxes, valid_indices = random_resized_crop(
+                image,
+                size=size,
+                scale=scale,
+                bboxes=bboxes,
+                seed=seeds[0],
+            )
+            crop, crop_bboxes = random_horizontal_flip(
+                crop, seed=seeds[1], bboxes=crop_bboxes
+            )
+            crop_labels = tf.gather(labels, valid_indices[:, 0])
+
+            crops_heatmaps.append({
+                "bboxes": crop_bboxes,
+                "labels": crop_labels
+            })
         else:
             crop = random_resized_crop(image, size=size, scale=scale, seed=seeds[0])
             crop = random_horizontal_flip(crop, seed=seeds[1])

--- a/hackathon/tasks.py
+++ b/hackathon/tasks.py
@@ -12,7 +12,6 @@ TASK_TYPE: dict[KnownDataset, TaskType] = {
     "voc/2012": "object_detection",
 }
 
-
 def get_processing_functions(
     dataset: KnownDataset,
     preproc_kwargs: dict,


### PR DESCRIPTION
## Summary
This PR completes the implementation of bounding box transformation logic in the create_global_crops() function in hackathon/augmentations.py.

##  Changes
- Applies random_resized_crop and random_horizontal_flip to images and bounding boxes.
- Filters out invalid (fully cropped out) bounding boxes.
- Extracts corresponding labels using valid indices.
- Stores per-crop detection targets as dictionaries with "bboxes" and "labels" under crops_heatmaps.
- Keeps the original output structure to avoid major changes in the data pipeline.

### Motivation
> Bounding box augmentation was previously unimplemented (NotImplementedError). This PR ensures that 
global crops of images are now paired with appropriately transformed bounding boxes and class labels, enabling object detection models to learn from augmented data.
closes #2 
